### PR TITLE
docs: add REUSE compliance badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 [![npm version](https://badge.fury.io/js/inquirerjs-checkbox-search.svg)](https://www.npmjs.com/package/inquirerjs-checkbox-search)
 [![code coverage](https://codecov.io/gh/Texarkanine/inquirerjs-checkbox-search/graph/badge.svg)](https://codecov.io/gh/Texarkanine/inquirerjs-checkbox-search)
+[![REUSE status](https://api.reuse.software/badge/github.com/Texarkanine/inquirerjs-checkbox-search)](https://api.reuse.software/info/github.com/Texarkanine/inquirerjs-checkbox-search)
 
 A multi-select prompt with text filtering/search capability for [inquirer.js](https://github.com/SBoudrias/Inquirer.js).
 


### PR DESCRIPTION
## Goal

Surface existing REUSE compliance on the README badge row.

## What's here

Adds the REUSE status badge to [README.md](https://github.com/Texarkanine/inquirerjs-checkbox-search/blob/docs/reuse-badge/README.md) (after the existing npm/coverage badges). No licensing file changes; the repo already passes `reuse lint`.

## How I know it works

**Evidence:**

`reuse lint` exit 0 on the branch before opening the PR.

<details>
<summary>Transcript</summary>

```

```

</details>

## What changes for a user

README shows a REUSE compliance badge linking to the REUSE API info page.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a REUSE compliance status badge linking to the repository’s REUSE information page.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->